### PR TITLE
net: prestera: update Prestera driver

### DIFF
--- a/drivers/net/ethernet/marvell/prestera/prestera.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera.h
@@ -32,6 +32,9 @@
 #define PRESTERA_SPAN_INVALID_ID -1
 #define PRESTERA_QOS_SP_COUNT 8
 
+#define PRESTERA_IPG_DEFAULT_VALUE (12)
+#define PRESTERA_IPG_ALIGN_VALUE (4)
+
 struct prestera_fw_rev {
 	u16 maj;
 	u16 min;

--- a/drivers/net/ethernet/marvell/prestera/prestera_fw.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_fw.h
@@ -67,7 +67,7 @@ struct prestera_fw_regs {
 
 #define PRESTERA_SUPP_FW_MAJ_VER	3
 #define PRESTERA_SUPP_FW_MIN_VER	2
-#define PRESTERA_SUPP_FW_PATCH_VER	1
+#define PRESTERA_SUPP_FW_PATCH_VER	2
 
 struct prestera_fw_evtq {
 	u8 __iomem *addr;

--- a/drivers/net/ethernet/marvell/prestera/prestera_hw.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_hw.h
@@ -314,9 +314,15 @@ int prestera_hw_fdb_flush_vlan(const struct prestera_switch *sw, u16 vid,
 int prestera_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
 				    u32 mode);
 int prestera_hw_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
-			    const u8 *mac, u16 vid);
+			    const u8 *mac, u16 vid,
+			    struct prestera_iface *iface);
 int prestera_hw_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
-			    const u8 *mac, u16 vid);
+			    const u8 *mac, u16 vid,
+			    struct prestera_iface *iface);
+int prestera_hw_fdb_routed_add(const struct prestera_switch *sw,
+			       const u8 *mac, u16 vid);
+int prestera_hw_fdb_routed_del(const struct prestera_switch *sw,
+			       const u8 *mac, u16 vid);
 
 /* Bridge API */
 int prestera_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id);
@@ -468,6 +474,10 @@ int prestera_hw_flood_domain_ports_reset(struct prestera_flood_domain *domain);
 
 int prestera_hw_mdb_create(struct prestera_mdb_entry *mdb);
 int prestera_hw_mdb_destroy(struct prestera_mdb_entry *mdb);
+
+/* HW IPG API */
+int prestera_hw_ipg_set(struct prestera_switch *sw, u32 ipg);
+int prestera_hw_ipg_get(struct prestera_switch *sw, u32 *ipg);
 
 /* QoS */
 int prestera_hw_port_qos_mapping_update(const struct prestera_port *port,

--- a/drivers/net/ethernet/marvell/prestera/prestera_router_hw.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_router_hw.c
@@ -235,7 +235,7 @@ static int __prestera_rif_entry_macvlan_add(const struct prestera_switch *sw,
 	 * Now it is inconsistent.
 	 */
 	err = prestera_hw_macvlan_add(sw, e->vr->hw_vr_id, addr,
-				      e->key.iface.vlan_id);
+				      e->key.iface.vlan_id, &e->key.iface);
 	if (err)
 		goto err_hw;
 
@@ -258,7 +258,7 @@ __prestera_rif_entry_macvlan_del(const struct prestera_switch *sw,
 	int err;
 
 	err = prestera_hw_macvlan_del(sw, e->vr->hw_vr_id, n->addr,
-				      e->key.iface.vlan_id);
+				      e->key.iface.vlan_id, &e->key.iface);
 	if (err)
 		pr_err("%s:%d failed to delete macvlan from hw err = %d",
 		       __func__, __LINE__, err);


### PR DESCRIPTION
Update prestera driver to v3.2.2

This version includes:
	- Support for IPG set via debugFS
	- Support for "routed" FDB entries
	- Suppoer for DHCP reply traps

To set IPG:

```bash
localhost# cat  /sys/kernel/debug/prestera/ipg
ipg: 12
localhost# echo 24 >   /sys/kernel/debug/prestera/ipg
localhost# cat  /sys/kernel/debug/prestera/ipg
ipg: 24
```

Signed-off-by: Taras Chornyi <taras.chornyi@plvision.eu>