### PR TITLE
net: prestera: Update Prestera driver to v4.0.0

### DIFF
--- a/drivers/net/ethernet/marvell/prestera/Kconfig
+++ b/drivers/net/ethernet/marvell/prestera/Kconfig
@@ -8,6 +8,7 @@ config PRESTERA
 	depends on NET_SWITCHDEV && VLAN_8021Q
 	depends on BRIDGE || BRIDGE=n
 	select NET_DEVLINK
+	select PHYLINK
 	help
 	  This driver supports Marvell Prestera Switch ASICs family.
 

--- a/drivers/net/ethernet/marvell/prestera/Makefile
+++ b/drivers/net/ethernet/marvell/prestera/Makefile
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0
 obj-$(CONFIG_PRESTERA)	+= prestera.o
-prestera-objs		:= prestera_main.o \
-			   prestera_hw.o prestera_switchdev.o prestera_devlink.o \
-			   prestera_fw_log.o prestera_rxtx.o prestera_dsa.o \
-			   prestera_router.o prestera_acl.o prestera_flow.o \
-			   prestera_flower.o prestera_matchall.o prestera_debugfs.o \
-			   prestera_ct.o prestera_ethtool.o prestera_counter.o \
-			   prestera_fw.o prestera_router_hw.o prestera_dcb.o prestera_qdisc.o
+prestera-objs		:= prestera_main.o prestera_hw.o prestera_dsa.o \
+			   prestera_rxtx.o prestera_devlink.o prestera_ethtool.o \
+			   prestera_switchdev.o prestera_acl.o prestera_flow.o \
+			   prestera_flower.o prestera_span.o prestera_counter.o \
+			   prestera_router.o prestera_router_hw.o prestera_matchall.o \
+			   prestera_ct.o prestera_dcb.o prestera_qdisc.o \
+			   prestera_fw.o prestera_debugfs.o prestera_fw_log.o \
+			   prestera_nve.o
 
 prestera-$(CONFIG_MRVL_PRESTERA_DEBUG) += prestera_log.o
 ccflags-$(CONFIG_MRVL_PRESTERA_DEBUG) += -DCONFIG_MRVL_PRESTERA_DEBUG

--- a/drivers/net/ethernet/marvell/prestera/prestera_counter.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_counter.h
@@ -11,6 +11,8 @@ struct prestera_counter_stats {
 	u64 bytes;
 };
 
+struct prestera_switch;
+struct prestera_counter;
 struct prestera_counter_block;
 
 int prestera_counter_init(struct prestera_switch *sw);

--- a/drivers/net/ethernet/marvell/prestera/prestera_dcb.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_dcb.c
@@ -323,19 +323,20 @@ static int prestera_dcb_port_app_update(struct prestera_port *port,
 static int prestera_dcb_port_app_flush(struct prestera_port *port,
 				       struct dcb_app *app)
 {
+	u8 default_prio = prestera_dcb_port_default_prio(port);
 	int err;
-
-	err = prestera_hw_port_qos_default_prio_set(port, 0);
-	if (err) {
-		netdev_err(port->net_dev,
-			   "Failed to reset default priority\n");
-		return err;
-	}
 
 	err = prestera_port_trust_mode_set(port, PRESTERA_HW_QOS_TRUST_MODE_L2);
 	if (err) {
 		netdev_err(port->net_dev,
 			   "Failed to reset trust mode\n");
+		return err;
+	}
+
+	err = prestera_hw_port_qos_default_prio_set(port, default_prio);
+	if (err) {
+		netdev_err(port->net_dev,
+			   "Failed to reset default priority\n");
 		return err;
 	}
 

--- a/drivers/net/ethernet/marvell/prestera/prestera_debugfs.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_debugfs.c
@@ -23,7 +23,7 @@
 
 #define SCT_CFG_SUBDIR_NAME		"sct"
 
-#define CPU_CODE_CNT_BUF_MAX_SIZE	(MVSW_PR_RXTX_CPU_CODE_MAX_NUM * 32)
+#define CPU_CODE_CNT_BUF_MAX_SIZE	(PRESTERA_RXTX_CPU_CODE_MAX_NUM * 32)
 
 static ssize_t prestera_cnt_read(struct file *file, char __user *ubuf,
 				 size_t count, loff_t *ppos);
@@ -294,7 +294,7 @@ int prestera_debugfs_init(struct prestera_switch *sw)
 		goto err_subdir_alloc;
 	}
 
-	for (i = 0; i < MVSW_PR_RXTX_CPU_CODE_MAX_NUM; ++i) {
+	for (i = 0; i < PRESTERA_RXTX_CPU_CODE_MAX_NUM; ++i) {
 		f_data.cpu_code = i;
 
 		snprintf(file_name, sizeof(file_name), "cpu_code_%d_stats", i);
@@ -330,7 +330,7 @@ int prestera_debugfs_init(struct prestera_switch *sw)
 		}
 	}
 
-	f_data.cpu_code = MVSW_PR_RXTX_CPU_CODE_MAX_NUM;
+	f_data.cpu_code = PRESTERA_RXTX_CPU_CODE_MAX_NUM;
 	f_data.cpu_code_cnt_type = CPU_CODE_CNT_TYPE_SW_TRAP;
 	debugfs_file = debugfs_create_file("cpu_code_stats", 0644,
 					   cpu_code_sw_cnt_trap_subdir,
@@ -409,7 +409,7 @@ static int prestera_cpu_code_cnt_get(u64 *stats, u8 cpu_code, u8 cnt_type)
 							 cpu_code, cnt_type,
 							 stats);
 	case CPU_CODE_CNT_TYPE_SW_TRAP:
-		*stats = mvsw_pr_rxtx_get_cpu_code_stats(cpu_code);
+		*stats = prestera_rxtx_get_cpu_code_stats(cpu_code);
 		return 0;
 	default:
 		return -EINVAL;
@@ -430,12 +430,12 @@ static ssize_t prestera_cnt_read(struct file *file, char __user *ubuf,
 
 	mutex_lock(&prestera_debugfs.cpu_code_cnt_buf_mtx);
 
-	if (f_data.cpu_code == MVSW_PR_RXTX_CPU_CODE_MAX_NUM) {
+	if (f_data.cpu_code == PRESTERA_RXTX_CPU_CODE_MAX_NUM) {
 		int i;
 
 		memset(buf, 0, CPU_CODE_CNT_BUF_MAX_SIZE);
 
-		for (i = 0; i < MVSW_PR_RXTX_CPU_CODE_MAX_NUM; ++i) {
+		for (i = 0; i < PRESTERA_RXTX_CPU_CODE_MAX_NUM; ++i) {
 			ret = prestera_cpu_code_cnt_get
 				(&cpu_code_stats, (u8)i,
 				 f_data.cpu_code_cnt_type);

--- a/drivers/net/ethernet/marvell/prestera/prestera_dsa.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_dsa.h
@@ -1,22 +1,34 @@
 /* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
 /* Copyright (c) 2019-2021 Marvell International Ltd. All rights reserved. */
 
-#ifndef _MVSW_PRESTERA_DSA_H_
-#define _MVSW_PRESTERA_DSA_H_
+#ifndef _PRESTERA_DSA_H_
+#define _PRESTERA_DSA_H_
 
 #include <linux/types.h>
 
-#define MVSW_PR_DSA_HLEN	16
+#define PRESTERA_DSA_HLEN	16
+#define PRESTERA_DSA_AC5_HLEN	8
 
-enum mvsw_pr_dsa_cmd {
-	/* DSA command is "To CPU" */
-	MVSW_NET_DSA_CMD_TO_CPU_E = 0,
+enum prestera_dsa_type {
+	/* 16 bytes eDSA for eARCH devices: AC3X, ALDRIN2, AC5X */
+	PRESTERA_DSA_TYPE_EDSA16 = 0,
 
-	/* DSA command is "FROM CPU" */
-	MVSW_NET_DSA_CMD_FROM_CPU_E,
+	/* 8 bytes extended DSA for AC5 */
+	PRESTERA_DSA_TYPE_EXTDSA8,
 };
 
-struct mvsw_pr_dsa_common {
+enum prestera_dsa_cmd {
+	/* DSA command is "To CPU" */
+	PRESTERA_DSA_CMD_TO_CPU = 0,
+
+	/* DSA command is "FROM CPU" */
+	PRESTERA_DSA_CMD_FROM_CPU = 1,
+
+	/* DSA command is "FORWARD" */
+	PRESTERA_DSA_CMD_FORWARD = 3,
+};
+
+struct prestera_dsa_common {
 	/* the value vlan priority tag (APPLICABLE RANGES: 0..7) */
 	u8 vpt;
 
@@ -27,7 +39,7 @@ struct mvsw_pr_dsa_common {
 	u16 vid;
 };
 
-struct mvsw_pr_dsa_to_cpu {
+struct prestera_dsa_to_cpu {
 	bool is_tagged;
 	u32 hw_dev_num;
 	bool src_is_trunk;
@@ -39,7 +51,7 @@ struct mvsw_pr_dsa_to_cpu {
 	} iface;
 };
 
-struct mvsw_pr_dsa_from_cpu {
+struct prestera_dsa_from_cpu {
 	struct prestera_iface dst_iface;	/* vid/port */
 	bool egr_filter_en;
 	bool egr_filter_registered;
@@ -48,18 +60,19 @@ struct mvsw_pr_dsa_from_cpu {
 	u32 dst_eport;	/* for port but not for vid */
 };
 
-struct mvsw_pr_dsa {
-	struct mvsw_pr_dsa_common common_params;
-	enum mvsw_pr_dsa_cmd dsa_cmd;
+struct prestera_dsa {
+	struct prestera_dsa_common common_params;
+	enum prestera_dsa_cmd dsa_cmd;
+	enum prestera_dsa_type dsa_type;
 	union {
-		struct mvsw_pr_dsa_to_cpu to_cpu;
-		struct mvsw_pr_dsa_from_cpu from_cpu;
+		struct prestera_dsa_to_cpu to_cpu;
+		struct prestera_dsa_from_cpu from_cpu;
 	} dsa_info;
 };
 
-int mvsw_pr_dsa_parse(const u8 *dsa_bytes_ptr,
-		      struct mvsw_pr_dsa *dsa_info_ptr);
-int mvsw_pr_dsa_build(const struct mvsw_pr_dsa *dsa_info_ptr,
-		      u8 *dsa_bytes_ptr);
+int prestera_dsa_parse(const u8 *dsa_bytes_ptr,
+		       struct prestera_dsa *dsa_info_ptr);
+int prestera_dsa_build(const struct prestera_dsa *dsa_info_ptr,
+		       u8 *dsa_bytes_ptr);
 
-#endif /* _MVSW_PRESTERA_DSA_H_ */
+#endif /* _PRESTERA_DSA_H_ */

--- a/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c
@@ -340,7 +340,7 @@ static void prestera_port_mdix_cache(struct prestera_port *port)
 
 	if (prestera_hw_port_phy_mode_get(port, &state->mdix,
 					  NULL, NULL, NULL)) {
-		netdev_warn(port->net_dev, "MDIX params get failed");
+		netdev_warn_once(port->net_dev, "MDIX params get failed");
 		state->mdix = ETH_TP_MDI_INVALID;
 	}
 }

--- a/drivers/net/ethernet/marvell/prestera/prestera_flow.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_flow.h
@@ -7,6 +7,28 @@
 #include <net/flow_offload.h>
 
 struct prestera_port;
+struct prestera_switch;
+
+struct prestera_flow_block_binding {
+	struct list_head list;
+	struct prestera_port *port;
+	int span_id;
+};
+
+struct prestera_flow_block {
+	struct list_head binding_list;
+	struct prestera_switch *sw;
+	struct net *net;
+	struct prestera_acl_ruleset *ruleset_zero;
+	struct flow_block_cb *block_cb;
+	struct list_head template_list;
+	struct {
+		u32 prio_min;
+		u32 prio_max;
+		bool bound;
+	} mall;
+	bool ingress;
+};
 
 int prestera_flow_block_setup(struct prestera_port *port,
 			      struct flow_block_offload *f);

--- a/drivers/net/ethernet/marvell/prestera/prestera_flower.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_flower.h
@@ -19,7 +19,7 @@ int prestera_flower_tmplt_create(struct prestera_flow_block *block,
 void prestera_flower_tmplt_destroy(struct prestera_flow_block *block,
 				   struct flow_cls_offload *f);
 void prestera_flower_template_cleanup(struct prestera_flow_block *block);
-int prestera_flower_prio_get(struct prestera_flow_block *block,
-			     u32 *prio);
+int prestera_flower_prio_get(struct prestera_flow_block *block, u32 chain_index,
+			     u32 *prio_min, u32 *prio_max);
 
 #endif /* _PRESTERA_FLOWER_H_ */

--- a/drivers/net/ethernet/marvell/prestera/prestera_fw.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_fw.h
@@ -65,9 +65,9 @@ struct prestera_fw_regs {
 #define prestera_fw_write(fw, reg, val)	writel(val, (fw)->hw_regs + (reg))
 #define prestera_fw_read(fw, reg)	readl((fw)->hw_regs + (reg))
 
-#define PRESTERA_SUPP_FW_MAJ_VER	3
-#define PRESTERA_SUPP_FW_MIN_VER	2
-#define PRESTERA_SUPP_FW_PATCH_VER	2
+#define PRESTERA_SUPP_FW_MAJ_VER	4
+#define PRESTERA_SUPP_FW_MIN_VER	0
+#define PRESTERA_SUPP_FW_PATCH_VER	0
 
 struct prestera_fw_evtq {
 	u8 __iomem *addr;

--- a/drivers/net/ethernet/marvell/prestera/prestera_matchall.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_matchall.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
+/* Copyright (c) 2022 Marvell International Ltd. All rights reserved. */
+
+#ifndef _PRESTERA_MATCHALL_H_
+#define _PRESTERA_MATCHALL_H_
+
+#include <net/pkt_cls.h>
+
+struct prestera_flow_block;
+
+int prestera_mall_replace(struct prestera_flow_block *block,
+			  struct tc_cls_matchall_offload *f);
+void prestera_mall_destroy(struct prestera_flow_block *block);
+int prestera_mall_prio_get(struct prestera_flow_block *block,
+			   u32 *prio_min, u32 *prio_max);
+
+#endif /* _PRESTERA_MATCHALL_H_ */

--- a/drivers/net/ethernet/marvell/prestera/prestera_nve.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_nve.c
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+/*
+ * Copyright (c) 2019-2020 Marvell International Ltd. All rights reserved.
+ *
+ */
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/rhashtable.h>
+
+#include "prestera.h"
+#include "prestera_hw.h"
+#include "prestera_log.h"
+
+static const struct rhashtable_params __prestera_l2tun_tep_ht_params = {
+	.key_offset  = offsetof(struct prestera_l2tun_tep, key),
+	.head_offset = offsetof(struct prestera_l2tun_tep, ht_node),
+	.key_len     = sizeof(struct prestera_l2tun_tep_key),
+	.automatic_shrinking = true,
+};
+
+static const struct rhashtable_params __prestera_l2tun_tt_ht_params = {
+	.key_offset  = offsetof(struct prestera_l2tun_tt, key),
+	.head_offset = offsetof(struct prestera_l2tun_tt, ht_node),
+	.key_len     = sizeof(struct prestera_l2tun_tt_key),
+	.automatic_shrinking = true,
+};
+
+static const struct rhashtable_params __prestera_l2tun_vp_hw_index_ht_params = {
+	.key_offset  = offsetof(struct prestera_l2tun_vp, hw_tep_id),
+	.head_offset = offsetof(struct prestera_l2tun_vp, hw_index_ht_node),
+	.key_len     = sizeof(u32),
+	.automatic_shrinking = true,
+};
+
+static const struct rhashtable_params __prestera_l2tun_vp_ht_params = {
+	.key_offset  = offsetof(struct prestera_l2tun_vp, key),
+	.head_offset = offsetof(struct prestera_l2tun_vp, ht_node),
+	.key_len     = sizeof(struct prestera_l2tun_vp_key),
+	.automatic_shrinking = true,
+};
+
+struct prestera_l2tun_vp *
+prestera_l2tun_vp_find(struct prestera_switch *sw,
+		       struct prestera_l2tun_vp_key *key)
+{
+	struct prestera_l2tun_vp *o;
+
+	o = rhashtable_lookup_fast(&sw->router->nve.l2tun_vp_ht, key,
+				   __prestera_l2tun_vp_ht_params);
+
+	return IS_ERR(o) ? NULL : o;
+}
+
+static void
+__prestera_l2tun_vp_destroy(struct prestera_switch *sw,
+			    struct prestera_l2tun_vp *o)
+{
+	/* Optional: Ensure that there are no more entries in FDB */
+	WARN_ON(prestera_hw_fdb_flush_tep(sw, o->hw_tep_id,
+					  PRESTERA_FDB_FLUSH_MODE_ALL));
+
+	rhashtable_remove_fast(&sw->router->nve.l2tun_vp_hw_index_ht,
+			       &o->hw_index_ht_node,
+			       __prestera_l2tun_vp_hw_index_ht_params);
+	rhashtable_remove_fast(&sw->router->nve.l2tun_vp_ht, &o->ht_node,
+			       __prestera_l2tun_vp_ht_params);
+	WARN_ON(prestera_hw_l2tun_tep_del(sw, o->hw_tep_id));
+	kfree(o);
+}
+
+static struct prestera_l2tun_vp *
+__prestera_l2tun_vp_create(struct prestera_switch *sw,
+			   struct prestera_l2tun_vp_key *key)
+{
+	struct prestera_l2tun_vp *o;
+	int err;
+
+	o = kzalloc(sizeof(*o), GFP_KERNEL);
+	if (!o)
+		goto err_kzalloc;
+
+	INIT_LIST_HEAD(&o->l2tun_tt_list);
+	INIT_LIST_HEAD(&o->l2tun_tep_list);
+	INIT_LIST_HEAD(&o->flood_domain_port_list);
+
+	memcpy(&o->key, key, sizeof(*key));
+
+	err = prestera_hw_l2tun_tep_create(sw, &o->hw_tep_id);
+	if (err)
+		goto err_hw_add;
+
+	err = rhashtable_insert_fast(&sw->router->nve.l2tun_vp_ht,
+				     &o->ht_node,
+				     __prestera_l2tun_vp_ht_params);
+	if (err)
+		goto err_ht_insert;
+
+	err = rhashtable_insert_fast(&sw->router->nve.l2tun_vp_hw_index_ht,
+				     &o->hw_index_ht_node,
+				     __prestera_l2tun_vp_hw_index_ht_params);
+	if (err)
+		goto err_hw_idx_ht_insert;
+
+	return o;
+
+err_hw_idx_ht_insert:
+	rhashtable_remove_fast(&sw->router->nve.l2tun_vp_ht, &o->ht_node,
+			       __prestera_l2tun_vp_ht_params);
+err_ht_insert:
+	WARN_ON(prestera_hw_l2tun_tep_del(sw, o->hw_tep_id));
+err_hw_add:
+	kfree(o);
+err_kzalloc:
+	return NULL;
+}
+
+struct prestera_l2tun_vp *
+prestera_l2tun_vp_get(struct prestera_switch *sw,
+		      struct prestera_l2tun_vp_key *key)
+{
+	struct prestera_l2tun_vp  *o;
+
+	o = prestera_l2tun_vp_find(sw, key);
+	if (o)
+		return o;
+
+	return __prestera_l2tun_vp_create(sw, key);
+}
+
+void prestera_l2tun_vp_put(struct prestera_switch *sw,
+			   struct prestera_l2tun_vp *o)
+{
+	if (list_empty(&o->l2tun_tt_list) &&
+	    list_empty(&o->l2tun_tep_list) &&
+	    list_empty(&o->flood_domain_port_list))
+		__prestera_l2tun_vp_destroy(sw, o);
+}
+
+struct prestera_l2tun_vp *
+prestera_l2tun_vp_find_hw_index(struct prestera_switch *sw, u32 id)
+{
+	struct prestera_l2tun_vp *o;
+
+	o = rhashtable_lookup_fast(&sw->router->nve.l2tun_vp_hw_index_ht, &id,
+				   __prestera_l2tun_vp_hw_index_ht_params);
+
+	return IS_ERR(o) ? NULL : o;
+}
+
+int prestera_l2tun_vp_util_fdb_set(struct prestera_switch *sw,
+				   struct prestera_l2tun_vp_key *key,
+				   u8 *mac, u16 vid, bool enable, bool dynamic)
+{
+	struct prestera_l2tun_vp *vp;
+	int err;
+
+	vp = prestera_l2tun_vp_find(sw, key);
+	/* This is util. So no need to dynamically create vp. */
+	if (!vp)
+		return -ENOENT;
+
+	if (enable)
+		err = prestera_hw_fdb_tep_add(sw, vp->hw_tep_id,
+					      mac, vid, dynamic);
+	else
+		err = prestera_hw_fdb_tep_del(sw, vp->hw_tep_id, mac, vid);
+
+	return err;
+}
+
+struct prestera_l2tun_tep *
+prestera_l2tun_tep_find(struct prestera_switch *sw,
+			struct prestera_l2tun_tep_key *key)
+{
+	struct prestera_l2tun_tep *tep;
+
+	tep = rhashtable_lookup_fast(&sw->router->nve.l2tun_tep_ht, key,
+				     __prestera_l2tun_tep_ht_params);
+
+	return IS_ERR(tep) ? NULL : tep;
+}
+
+void prestera_l2tun_tep_destroy(struct prestera_switch *sw,
+				struct prestera_l2tun_tep *tep)
+{
+	WARN_ON(prestera_hw_l2tun_tep_clear(sw, tep->vp->hw_tep_id));
+
+	rhashtable_remove_fast(&sw->router->nve.l2tun_tep_ht, &tep->ht_node,
+			       __prestera_l2tun_tep_ht_params);
+	list_del(&tep->nh_neigh_head);
+	prestera_nh_neigh_put(sw, tep->n);
+	list_del(&tep->l2tun_vp_head);
+	prestera_l2tun_vp_put(sw, tep->vp);
+	kfree(tep);
+}
+
+int prestera_l2tun_tep_set(struct prestera_switch *sw,
+			   struct prestera_l2tun_tep *tep)
+{
+	int err;
+
+	err = prestera_hw_l2tun_tep_set(sw, tep->vp->hw_tep_id, tep->n->info,
+					tep->cfg.dip.u.ipv4,
+					tep->cfg.sip.u.ipv4,
+					tep->cfg.l4_dst, tep->cfg.l4_src,
+					tep->cfg.vni, tep->cfg.source_id);
+	if (err) {
+		pr_err("prestera_hw_l2tun_tep_set failed");
+		return err;
+	}
+
+	return 0;
+}
+
+struct prestera_l2tun_tep *
+prestera_l2tun_tep_create(struct prestera_switch *sw,
+			  struct prestera_l2tun_tep_key *key,
+			  struct prestera_l2tun_tep_cfg *cfg,
+			  struct prestera_nh_neigh_key *n_key)
+{
+	struct prestera_l2tun_tep *tep;
+	int err;
+
+	tep = kzalloc(sizeof(*tep), GFP_KERNEL);
+	if (!tep)
+		goto err_kzalloc;
+
+	memcpy(&tep->key, key, sizeof(*key));
+	memcpy(&tep->cfg, cfg, sizeof(*cfg));
+
+	tep->n = prestera_nh_neigh_get(sw, n_key);
+	if (!tep->n)
+		goto err_nh_get;
+
+	list_add(&tep->nh_neigh_head, &tep->n->l2tun_tep_list);
+
+	tep->vp = prestera_l2tun_vp_get(sw, &key->vp_key);
+	if (!tep->vp)
+		goto err_vp_get;
+
+	list_add(&tep->l2tun_vp_head, &tep->vp->l2tun_tep_list);
+
+	err = prestera_l2tun_tep_set(sw, tep);
+	if (err)
+		goto err_tep_set;
+
+	err = rhashtable_insert_fast(&sw->router->nve.l2tun_tep_ht,
+				     &tep->ht_node,
+				     __prestera_l2tun_tep_ht_params);
+	if (err)
+		goto err_ht_insert;
+
+	return tep;
+
+err_ht_insert:
+	WARN_ON(prestera_hw_l2tun_tep_clear(sw, tep->vp->hw_tep_id));
+err_tep_set:
+	list_del(&tep->l2tun_vp_head);
+	prestera_l2tun_vp_put(sw, tep->vp);
+err_vp_get:
+	list_del(&tep->nh_neigh_head);
+	prestera_nh_neigh_put(sw, tep->n);
+err_nh_get:
+	kfree(tep);
+err_kzalloc:
+	return NULL;
+}
+
+struct prestera_l2tun_tt *
+prestera_l2tun_tt_find(struct prestera_switch *sw,
+		       struct prestera_l2tun_tt_key *key)
+{
+	struct prestera_l2tun_tt *tt;
+
+	tt = rhashtable_lookup_fast(&sw->router->nve.l2tun_tt_ht, key,
+				    __prestera_l2tun_tt_ht_params);
+
+	return IS_ERR(tt) ? NULL : tt;
+}
+
+void prestera_l2tun_tt_destroy(struct prestera_switch *sw,
+			       struct prestera_l2tun_tt *tt)
+{
+	WARN_ON(prestera_hw_l2tun_tt_del(sw, tt->hw_tt_id));
+
+	rhashtable_remove_fast(&sw->router->nve.l2tun_tt_ht, &tt->ht_node,
+			       __prestera_l2tun_tt_ht_params);
+	if (tt->vp) {
+		list_del(&tt->l2tun_vp_head);
+		prestera_l2tun_vp_put(sw, tt->vp);
+	}
+
+	kfree(tt);
+}
+
+struct prestera_l2tun_tt *
+prestera_l2tun_tt_create(struct prestera_switch *sw,
+			 struct prestera_l2tun_tt_key *key, u16 pvid,
+			 struct prestera_l2tun_vp_key *vp_key, u32 source_id)
+{
+	struct prestera_l2tun_tt *tt;
+	int err;
+
+	tt = kzalloc(sizeof(*tt), GFP_KERNEL);
+	if (!tt)
+		goto err_kzalloc;
+
+	/* Sanitize key */
+	if (!key->match_src_ip)
+		memset(&key->src_ip, 0, sizeof(key->src_ip));
+
+	memcpy(&tt->key, key, sizeof(*key));
+	tt->pvid = pvid;
+	tt->source_id = source_id;
+
+	if (vp_key) {
+		tt->vp = prestera_l2tun_vp_get(sw, vp_key);
+		if (!tt->vp)
+			goto err_vp_get;
+
+		list_add(&tt->l2tun_vp_head, &tt->vp->l2tun_tt_list);
+	}
+
+	err = prestera_hw_l2tun_tt_create(sw, key->ip.u.ipv4,
+					  key->match_src_ip, key->src_ip.u.ipv4,
+					  key->port, key->vni,
+					  tt->vp ? tt->vp->hw_tep_id : 0,
+					  tt->pvid, tt->source_id,
+					  &tt->hw_tt_id);
+	if (err)
+		goto err_hw_create;
+
+	err = rhashtable_insert_fast(&sw->router->nve.l2tun_tt_ht,
+				     &tt->ht_node,
+				     __prestera_l2tun_tt_ht_params);
+	if (err)
+		goto err_ht_insert;
+
+	return tt;
+
+err_ht_insert:
+	prestera_hw_l2tun_tt_del(sw, tt->hw_tt_id);
+err_hw_create:
+	if (tt->vp) {
+		list_del(&tt->l2tun_vp_head);
+		prestera_l2tun_vp_put(sw, tt->vp);
+	}
+err_vp_get:
+	kfree(tt);
+err_kzalloc:
+	return NULL;
+}
+
+int prestera_l2tun_init(struct prestera_switch *sw)
+{
+	int err;
+
+	err = rhashtable_init(&sw->router->nve.l2tun_vp_ht,
+			      &__prestera_l2tun_vp_ht_params);
+	if (err)
+		goto err_l2tun_vp_ht;
+
+	err = rhashtable_init(&sw->router->nve.l2tun_vp_hw_index_ht,
+			      &__prestera_l2tun_vp_hw_index_ht_params);
+	if (err)
+		goto err_l2tun_vp_hw_index_ht;
+
+	err = rhashtable_init(&sw->router->nve.l2tun_tep_ht,
+			      &__prestera_l2tun_tep_ht_params);
+	if (err)
+		goto err_l2tun_tep_ht;
+
+	err = rhashtable_init(&sw->router->nve.l2tun_tt_ht,
+			      &__prestera_l2tun_tt_ht_params);
+	if (err)
+		goto err_l2tun_tt_ht;
+
+	return 0;
+
+err_l2tun_tt_ht:
+	rhashtable_destroy(&sw->router->nve.l2tun_tep_ht);
+err_l2tun_tep_ht:
+	rhashtable_destroy(&sw->router->nve.l2tun_vp_hw_index_ht);
+err_l2tun_vp_hw_index_ht:
+	rhashtable_destroy(&sw->router->nve.l2tun_vp_ht);
+err_l2tun_vp_ht:
+	return err;
+}
+
+void prestera_l2tun_fini(struct prestera_switch *sw)
+{
+	/* TODO: clear all hw entries (walk ht) */
+
+	rhashtable_destroy(&sw->router->nve.l2tun_tt_ht);
+	rhashtable_destroy(&sw->router->nve.l2tun_tep_ht);
+	rhashtable_destroy(&sw->router->nve.l2tun_vp_hw_index_ht);
+	rhashtable_destroy(&sw->router->nve.l2tun_vp_ht);
+}

--- a/drivers/net/ethernet/marvell/prestera/prestera_qdisc.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_qdisc.c
@@ -581,6 +581,10 @@ static int __prestera_setup_tc_tbf(struct prestera_port *port,
 	if (!qdisc)
 		return -EOPNOTSUPP;
 
+	/* tbf as root is not supported */
+	if (qdisc == &port->qdisc->root_qdisc)
+		return -EOPNOTSUPP;
+
 	if (p->command == TC_TBF_REPLACE)
 		return prestera_qdisc_replace(port, p->handle, qdisc,
 					      &prestera_qdisc_tbf_ops,
@@ -627,6 +631,10 @@ static int __prestera_setup_tc_red(struct prestera_port *port,
 
 	qdisc = prestera_qdisc_find(port, p->parent);
 	if (!qdisc)
+		return -EOPNOTSUPP;
+
+	/* red as root is not supported */
+	if (qdisc == &port->qdisc->root_qdisc)
 		return -EOPNOTSUPP;
 
 	if (p->command == TC_RED_REPLACE)

--- a/drivers/net/ethernet/marvell/prestera/prestera_rxtx.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_rxtx.h
@@ -1,12 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
 /* Copyright (c) 2019-2021 Marvell International Ltd. All rights reserved. */
 
-#ifndef _MVSW_PRESTERA_RXTX_H_
-#define _MVSW_PRESTERA_RXTX_H_
+#ifndef _PRESTERA_RXTX_H_
+#define _PRESTERA_RXTX_H_
 
 #include <linux/netdevice.h>
 
-#define MVSW_PR_RXTX_CPU_CODE_MAX_NUM	256
+#define PRESTERA_RXTX_CPU_CODE_MAX_NUM	256
 
 struct prestera_switch;
 
@@ -15,6 +15,6 @@ void prestera_rxtx_switch_fini(struct prestera_switch *sw);
 
 netdev_tx_t prestera_rxtx_xmit(struct sk_buff *skb, struct prestera_port *port);
 
-u64 mvsw_pr_rxtx_get_cpu_code_stats(u8 cpu_code);
+u64 prestera_rxtx_get_cpu_code_stats(u8 cpu_code);
 
-#endif /* _MVSW_PRESTERA_RXTX_H_ */
+#endif /* _PRESTERA_RXTX_H_ */

--- a/drivers/net/ethernet/marvell/prestera/prestera_span.c
+++ b/drivers/net/ethernet/marvell/prestera/prestera_span.c
@@ -7,6 +7,7 @@
 #include "prestera.h"
 #include "prestera_hw.h"
 #include "prestera_acl.h"
+#include "prestera_flow.h"
 #include "prestera_span.h"
 
 struct prestera_span_entry {
@@ -99,14 +100,14 @@ static int prestera_span_get(struct prestera_port *port, u8 *span_id)
 	return 0;
 }
 
-static int prestera_span_put(struct prestera_switch *sw, u8 span_id)
+static int prestera_span_put(const struct prestera_switch *sw, u8 span_id)
 {
 	struct prestera_span_entry *entry;
 	int err;
 
 	entry = prestera_span_entry_find_by_id(sw->span, span_id);
 	if (!entry)
-		return false;
+		return -ENOENT;
 
 	if (!refcount_dec_and_test(&entry->ref_count))
 		return 0;
@@ -119,8 +120,9 @@ static int prestera_span_put(struct prestera_switch *sw, u8 span_id)
 	return 0;
 }
 
-static int prestera_span_rule_add(struct prestera_flow_block_binding *binding,
-				  struct prestera_port *to_port)
+int prestera_span_rule_add(struct prestera_flow_block_binding *binding,
+			   struct prestera_port *to_port,
+			   bool ingress)
 {
 	struct prestera_switch *sw = binding->port->sw;
 	u8 span_id;
@@ -134,7 +136,7 @@ static int prestera_span_rule_add(struct prestera_flow_block_binding *binding,
 	if (err)
 		return err;
 
-	err = prestera_hw_span_bind(binding->port, span_id);
+	err = prestera_hw_span_bind(binding->port, span_id, ingress);
 	if (err) {
 		prestera_span_put(sw, span_id);
 		return err;
@@ -144,11 +146,15 @@ static int prestera_span_rule_add(struct prestera_flow_block_binding *binding,
 	return 0;
 }
 
-static int prestera_span_rule_del(struct prestera_flow_block_binding *binding)
+int prestera_span_rule_del(struct prestera_flow_block_binding *binding,
+			   bool ingress)
 {
 	int err;
 
-	err = prestera_hw_span_unbind(binding->port);
+	if (binding->span_id == PRESTERA_SPAN_INVALID_ID)
+		return -ENOENT;
+
+	err = prestera_hw_span_unbind(binding->port, ingress);
 	if (err)
 		return err;
 
@@ -158,60 +164,6 @@ static int prestera_span_rule_del(struct prestera_flow_block_binding *binding)
 
 	binding->span_id = PRESTERA_SPAN_INVALID_ID;
 	return 0;
-}
-
-int prestera_span_replace(struct prestera_flow_block *block,
-			  struct tc_cls_matchall_offload *f)
-{
-	struct prestera_flow_block_binding *binding;
-	__be16 protocol = f->common.protocol;
-	struct flow_action_entry *act;
-	struct prestera_port *port;
-	int err;
-
-	if (!flow_offload_has_one_action(&f->rule->action)) {
-		NL_SET_ERR_MSG(f->common.extack,
-			       "Only singular actions are supported");
-		return -EOPNOTSUPP;
-	}
-
-	act = &f->rule->action.entries[0];
-
-	if (!prestera_netdev_check(act->dev)) {
-		NL_SET_ERR_MSG(f->common.extack,
-			       "Only Marvell Prestera port is supported");
-		return -EINVAL;
-	}
-	if (!tc_cls_can_offload_and_chain0(act->dev, &f->common))
-		return -EOPNOTSUPP;
-	if (act->id != FLOW_ACTION_MIRRED)
-		return -EOPNOTSUPP;
-	if (protocol != htons(ETH_P_ALL))
-		return -EOPNOTSUPP;
-
-	port = netdev_priv(act->dev);
-
-	list_for_each_entry(binding, &block->binding_list, list) {
-		err = prestera_span_rule_add(binding, port);
-		if (err)
-			goto rollback;
-	}
-
-	return 0;
-
-rollback:
-	list_for_each_entry_continue_reverse(binding,
-					     &block->binding_list, list)
-		prestera_span_rule_del(binding);
-	return err;
-}
-
-void prestera_span_destroy(struct prestera_flow_block *block)
-{
-	struct prestera_flow_block_binding *binding;
-
-	list_for_each_entry(binding, &block->binding_list, list)
-		prestera_span_rule_del(binding);
 }
 
 int prestera_span_init(struct prestera_switch *sw)

--- a/drivers/net/ethernet/marvell/prestera/prestera_span.h
+++ b/drivers/net/ethernet/marvell/prestera/prestera_span.h
@@ -8,13 +8,17 @@
 
 #define PRESTERA_SPAN_INVALID_ID -1
 
+struct prestera_port;
 struct prestera_switch;
-struct prestera_flow_block;
+struct prestera_flow_block_binding;
 
 int prestera_span_init(struct prestera_switch *sw);
 void prestera_span_fini(struct prestera_switch *sw);
-int prestera_span_replace(struct prestera_flow_block *block,
-			  struct tc_cls_matchall_offload *f);
-void prestera_span_destroy(struct prestera_flow_block *block);
+
+int prestera_span_rule_add(struct prestera_flow_block_binding *binding,
+			   struct prestera_port *to_port,
+			   bool ingress);
+int prestera_span_rule_del(struct prestera_flow_block_binding *binding,
+			   bool ingress);
 
 #endif /* _PRESTERA_SPAN_H_ */


### PR DESCRIPTION
This version includes:
	- MDB Offloading
	- Static LAG support
	- IPv6 offloading
	- QoS offloading
	- BR Locked offloading
	- Egress ACL
	- Egress Policer

Signed-off-by: Taras Chornyi <taras.chornyi@plvision.eu>